### PR TITLE
MAINT: stats._contains_nan: only detect numeric np.nan, not string 'nan'

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -103,7 +103,12 @@ def _contains_nan(a, nan_policy='propagate'):
             try:
                 # This can happen when attempting to check nan with np.isnan
                 # for string array (e.g. as in the function `rankdata`).
-                contains_nan = np.any(a == "nan")
+                contains_nan = False
+                for el in a.ravel():
+                    # isnan doesn't work on elements of string arrays
+                    if np.issubdtype(type(el), np.number) and np.isnan(el):
+                        contains_nan = True
+                        break
             except TypeError:
                 # Don't know what to do. Fall back to omitting nan values and
                 # issue a warning.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7553,8 +7553,8 @@ class TestContainsNaNTest:
         data4 = np.array([1, 2, "3", np.nan])  # converted to string "nan"
         assert not _contains_nan(data4)[0]
 
-        data4 = np.array([1, 2, "3", np.nan], dtype='object')
-        assert _contains_nan(data4)[0]
+        data5 = np.array([1, 2, "3", np.nan], dtype='object')
+        assert _contains_nan(data5)[0]
 
     def test_contains_nan_2d(self):
         data1 = np.array([[1, 2], [3, 4]])
@@ -7566,5 +7566,5 @@ class TestContainsNaNTest:
         data3 = np.array([["1", 2], [3, np.nan]])  # converted to string "nan"
         assert not _contains_nan(data3)[0]
 
-        data3 = np.array([["1", 2], [3, np.nan]], dtype='object')
-        assert _contains_nan(data3)[0]
+        data4 = np.array([["1", 2], [3, np.nan]], dtype='object')
+        assert _contains_nan(data4)[0]

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7550,7 +7550,10 @@ class TestContainsNaNTest:
         data3 = np.array([np.nan, 2, 3, np.nan])
         assert _contains_nan(data3)[0]
 
-        data4 = np.array([1, 2, "3", np.nan])
+        data4 = np.array([1, 2, "3", np.nan])  # converted to string "nan"
+        assert not _contains_nan(data4)[0]
+
+        data4 = np.array([1, 2, "3", np.nan], dtype='object')
         assert _contains_nan(data4)[0]
 
     def test_contains_nan_2d(self):
@@ -7560,5 +7563,8 @@ class TestContainsNaNTest:
         data2 = np.array([[1, 2], [3, np.nan]])
         assert _contains_nan(data2)[0]
 
-        data3 = np.array([["1", 2], [3, np.nan]])
+        data3 = np.array([["1", 2], [3, np.nan]])  # converted to string "nan"
+        assert not _contains_nan(data3)[0]
+
+        data3 = np.array([["1", 2], [3, np.nan]], dtype='object')
         assert _contains_nan(data3)[0]


### PR DESCRIPTION
#### Reference issue
scipy/scipy#16238

#### What does this implement/fix?
Even if we're going to deprecate support for non-numeric data in `rankdata`, I'm not sure if we should let the string "nan" be considered a np.nan in the meantime. Even if it doesn't make a practical difference, I don't want to invite criticism for doing something that is not strictly correct.

We could write this using, say, `filter` instead of an explicit loop, but I thought this was more readable, it has the advantage of breaking early if it finds a `nan`, and I don't think we care about speed. Ultimately, NumPy needs to make `np.isnan` accept other data types if we hope to make this fast, so let's keep it simple.